### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
 	"name": "ngSweetAlert",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"main": "./SweetAlert.js",
 	"authors": [
 		"pedro@oitozero.com",
@@ -25,7 +25,7 @@
 	],
 	"dependencies": {
 		"angular":"~1.2.0",
-		"sweetalert":"~0.3.0"
+		"sweetalert":">=0.3.0"
 	},
 	"devDependencies": {
 	}


### PR DESCRIPTION
Update repo version.
Request SweetAlert versions greater than o equals to v0.3.0 due quick changes in the SweetAlert project, and in order to allow all the new features and fixes.

Related issue #13 