### PR TITLE
Made compatible with NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "angular-sweetalert",
+  "version": "1.0.4",
+  "description": "AngularJS wrapper for SweetAlert",
+  "main": "SweetAlert.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/oitozero/ngSweetAlert.git"
+  },
+  "keywords": [
+    "angular",
+    "AngularJs",
+    "sweetalert",
+    "sweet",
+    "alert"
+  ],
+  "author": "pedro@oitozero.com, gnick666@gmail.com",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/oitozero/ngSweetAlert/issues"
+  },
+  "dependencies": {
+    "angular": "^1.3.14",
+    "sweetalert": "^0.4.2"
+  }
+}


### PR DESCRIPTION
I wanted to install this from NPM for my NW.js project, but it wasn't there! This is an outrage! Just `npm publish` after merging to get it onto the NPM registry.