### PR TITLE
add support for showInputError() and close()

### DIFF
--- a/SweetAlert.js
+++ b/SweetAlert.js
@@ -43,12 +43,22 @@ angular.module('oitozero.ngSweetAlert', [])
 				swal( title, message, 'warning' );
 			});
 		},
-		info: function(title, message) {	
+		info: function(title, message) {
 			$rootScope.$evalAsync(function(){
 				swal( title, message, 'info' );
 			});
+		},
+		showInputError: function(message) {
+			$rootScope.$evalAsync(function(){
+	      swal.showInputError( message );
+	    });
+		},
+		close: function() {
+			$rootScope.$evalAsync(function(){
+	        swal.close();
+	    });
 		}
 	};
-	
+
 	return self;
 }]);


### PR DESCRIPTION
* closes #39
* expose SweetAlert.showInputError and SweetAlert.close functions (in both cases delegate them to `window.swal`, just like everything else does)