### PR TITLE
Fix SweetAlert dependency version in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,7 @@
 	],
 	"dependencies": {
 		"angular":">=1.3.0",
-		"sweetalert":">=0.3.0"
+		"sweetalert":"^1.0.0"
 	},
 	"devDependencies": {
 	}


### PR DESCRIPTION
There is a new SweetAlert major release (v2.0.0) which has been rolled out in the past hours:
https://github.com/t4t5/sweetalert/releases/tag/v2.0.0

Since we are targeting versions equal or greater than 0.3.0, this module will break as soon as users update their dependencies.

This PR changes the dependency version to a more restrict one. This will hopefully fix #78 .